### PR TITLE
Also hide Extracting dir messages behind verbose flag.

### DIFF
--- a/untar.c
+++ b/untar.c
@@ -276,8 +276,11 @@ int untar(FILE *a, char const* path)
 		}
 		else if('5' == op)
 		{
-			fputs(" Extracting dir ", stdout);
-			puts(buff);
+			if(VERBOSE)
+			{
+				fputs(" Extracting dir ", stdout);
+				puts(buff);
+			}
 			create_dir(buff, parseoct(buff + 100, 8));
 			filesize = 0;
 		}


### PR DESCRIPTION
Remaining messages are worth keeping explicit (e.g. that symlinks/hardlinks are unsupported) but I think we can hide directory extraction messages behind verbose flag.