### PR TITLE
Mount /dev/pts in the wrap environment

### DIFF
--- a/wrap.c
+++ b/wrap.c
@@ -166,6 +166,7 @@ int main(int argc, char **argv)
 		mkmount ("/dev/random", "dev/random", "", MS_BIND, NULL, 0);
 		mkmount ("/dev/urandom", "dev/urandom", "", MS_BIND, NULL, 0);
 		mkmount ("/dev/ptmx", "dev/ptmx", "", MS_BIND, NULL, 0);
+		mkmount ("/dev/pts", "dev/pts", "", MS_BIND, NULL, 1);
 		mkmount ("/dev/tty", "dev/tty", "", MS_BIND, NULL, 0);
 		mkmount ("tmpfs", "dev/shm", "tmpfs", 0, NULL, 1);
 		mkmount ("/proc", "proc", "", MS_BIND | MS_REC, NULL, 1);


### PR DESCRIPTION
This allows pseudo terminals to be opened in the wrapped environment